### PR TITLE
Fix file output decoding

### DIFF
--- a/dist-commonjs/steps/UploadStep/components/DropZone.js
+++ b/dist-commonjs/steps/UploadStep/components/DropZone.js
@@ -58,7 +58,13 @@ const DropZone = ({ onContinue, isLoading }) => {
         onDrop: async ([file]) => {
             setLoading(true);
             const arrayBuffer = await readFilesAsync.readFileAsync(file);
-            const workbook = XLSX__namespace.read(arrayBuffer, { cellDates: true, dateNF: dateFormat, raw: parseRaw });
+            const workbook = XLSX__namespace.read(arrayBuffer, {
+                cellDates: true,
+                dateNF: dateFormat,
+                raw: parseRaw,
+                type: "buffer",
+                codepage: 65001,
+            });
             setLoading(false);
             onContinue(workbook);
         },

--- a/dist/steps/UploadStep/components/DropZone.js
+++ b/dist/steps/UploadStep/components/DropZone.js
@@ -34,7 +34,13 @@ const DropZone = ({ onContinue, isLoading }) => {
         onDrop: async ([file]) => {
             setLoading(true);
             const arrayBuffer = await readFileAsync(file);
-            const workbook = XLSX.read(arrayBuffer, { cellDates: true, dateNF: dateFormat, raw: parseRaw });
+            const workbook = XLSX.read(arrayBuffer, {
+                cellDates: true,
+                dateNF: dateFormat,
+                raw: parseRaw,
+                type: "buffer",
+                codepage: 65001,
+            });
             setLoading(false);
             onContinue(workbook);
         },

--- a/src/steps/UploadStep/components/DropZone.tsx
+++ b/src/steps/UploadStep/components/DropZone.tsx
@@ -39,7 +39,13 @@ export const DropZone = ({ onContinue, isLoading }: DropZoneProps) => {
     onDrop: async ([file]) => {
       setLoading(true)
       const arrayBuffer = await readFileAsync(file)
-      const workbook = XLSX.read(arrayBuffer, { cellDates: true, dateNF: dateFormat, raw: parseRaw })
+      const workbook = XLSX.read(arrayBuffer, {
+        cellDates: true,
+        dateNF: dateFormat,
+        raw: parseRaw,
+        type: "buffer",
+        codepage: 65001,
+      })
       setLoading(false)
       onContinue(workbook)
     },


### PR DESCRIPTION
I Googled around a bunch and I think this is a decoding issue where the output was not being encoded as utf-8.

I ran a file with a small variety of special characters and I didn't see any more issues.

Spreadsheet:
<img width="640" alt="image" src="https://user-images.githubusercontent.com/1479563/234396504-b7d219ce-579f-4cc3-b8e2-8995cebcc178.png">

Current:
<img width="555" alt="image" src="https://user-images.githubusercontent.com/1479563/234396554-9572f28f-281e-48e8-9559-9ddacbc19b39.png">

Fixed:
<img width="553" alt="image" src="https://user-images.githubusercontent.com/1479563/234396608-6c993530-e000-4c95-bfab-9dbcfd997e94.png">
