### PR TITLE
Clear selection on filter change

### DIFF
--- a/src/steps/ValidationStep/ValidationStep.tsx
+++ b/src/steps/ValidationStep/ValidationStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { Box, Button, Heading, ModalBody, Switch, useStyleConfig, useToast } from "@chakra-ui/react"
 import { ContinueButton } from "../../components/ContinueButton"
 import { useRsi } from "../../hooks/useRsi"
@@ -30,6 +30,11 @@ export const ValidationStep = <T extends string>({ initialData, file, onBack }: 
   const [filterByErrors, setFilterByErrors] = useState(false)
   const [showSubmitAlert, setShowSubmitAlert] = useState(false)
   const [isSubmitting, setSubmitting] = useState(false)
+
+  const clearSelectionAndUpdateFilter = () => {
+    setSelectedRows(new Set())
+    setFilterByErrors(!filterByErrors)
+  }
 
   const updateData = useCallback(
     async (rows: typeof data, indexes?: number[]) => {
@@ -151,7 +156,7 @@ export const ValidationStep = <T extends string>({ initialData, file, onBack }: 
               display="flex"
               alignItems="center"
               isChecked={filterByErrors}
-              onChange={() => setFilterByErrors(!filterByErrors)}
+              onChange={clearSelectionAndUpdateFilter}
             >
               {translations.validationStep.filterSwitchTitle}
             </Switch>

--- a/src/steps/ValidationStep/tests/ValidationStep.test.tsx
+++ b/src/steps/ValidationStep/tests/ValidationStep.test.tsx
@@ -141,7 +141,7 @@ describe("Validation step tests", () => {
     expect(onClose).not.toBeCalled()
   })
 
-  test("Filters rows with required errors", async () => {
+  test("Filters rows with required errors, clears selection", async () => {
     const UNIQUE_NAME = "very unique name"
     const fields = [
       {
@@ -183,12 +183,24 @@ describe("Validation step tests", () => {
     const validRow = screen.getByText(UNIQUE_NAME)
     expect(validRow).toBeInTheDocument()
 
-    const switchFilter = getFilterSwitch()
+    const selectCheckboxes = screen.getAllByRole("checkbox", {
+      name: "Select",
+    })
+    await userEvent.click(selectCheckboxes[0])
+    expect(selectCheckboxes[0]).toBeChecked()
 
+    const switchFilter = getFilterSwitch()
     await userEvent.click(switchFilter)
 
     const filteredRowsWithHeader = await screen.findAllByRole("row")
     expect(filteredRowsWithHeader).toHaveLength(2)
+
+    // selection was cleared with the filter
+    await userEvent.click(switchFilter)
+    const clearedSelectCheckboxes = screen.getAllByRole("checkbox", {
+      name: "Select",
+    })
+    expect(clearedSelectCheckboxes[0]).not.toBeChecked()
   })
 
   test("Filters rows with errors, fixes row, removes filter", async () => {


### PR DESCRIPTION
When importing past answers, the discard action doesn’t apply to just the filtered / visible questions which is confusing ([thread](https://conveyor-group.slack.com/archives/C0264ELBBNY/p1735014788401399?thread_ts=1734993097.506749&cid=C0264ELBBNY))
![image](https://github.com/user-attachments/assets/54eebdd6-3e65-44e4-a98b-e354784ed765)

Before
![Screenshot 2025-01-27 at 11 34 20 AM](https://github.com/user-attachments/assets/f1f6578e-31d1-4f28-acf3-a7254887c879)
![before-clear-selection](https://github.com/user-attachments/assets/fb1ed48e-3636-4154-9b83-f3286a917e0c)

After
![Screenshot 2025-01-27 at 11 34 33 AM](https://github.com/user-attachments/assets/caa3e57f-5d10-4ffd-8883-211ad6501436)
![after-clear-selection](https://github.com/user-attachments/assets/49038c80-b217-4957-a368-9cf0cd6a5165)



